### PR TITLE
fix: add permissions and git config for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -16,6 +21,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -25,6 +31,12 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
 
       - name: Release
         env:


### PR DESCRIPTION
## 🔧 Fix: Semantic Release Permissions

Fixes the  error in the semantic-release workflow.

### 🐛 Problem
The semantic-release workflow was failing with:


This occurred because the default  lacked sufficient permissions to push tags and commits back to the repository.

### ✅ Solution
1. **Added explicit permissions** to the workflow:
   -  - for pushing commits and tags
   -  - for creating releases  
   -  - for release notes

2. **Configured Git credentials** properly:
   - Set git user as 
   - Configure remote URL with GitHub token
   - Use  in checkout for security

### 🧪 Testing
- ✅ YAML syntax validates
- ✅ Follows GitHub Actions best practices
- ✅ Uses conventional commit format for this fix

This should resolve the permissions issue and allow semantic-release to properly create releases with version tags.