### PR TITLE
fix: install files to user's current working directory

### DIFF
--- a/bin/idk-install
+++ b/bin/idk-install
@@ -10,7 +10,10 @@ const projectRoot = path.dirname(scriptDir);
 const installScript = path.join(projectRoot, 'install.sh');
 
 // Get installation directory from command line args or use default
+// Make it absolute path relative to user's current working directory
+const userCwd = process.cwd();
 const installDir = process.argv[2] || './docs';
+const absoluteInstallDir = path.resolve(userCwd, installDir);
 
 console.log('Information Dense Keywords Dictionary Installer (npx)');
 console.log('===================================================\n');
@@ -22,8 +25,9 @@ if (!fs.existsSync(installScript)) {
 }
 
 try {
-    // Execute the install script
-    execSync(`bash "${installScript}" "${installDir}"`, {
+    // Execute the install script with absolute path for install directory
+    // but run from package root so it can find source files
+    execSync(`bash "${installScript}" "${absoluteInstallDir}"`, {
         stdio: 'inherit',
         cwd: projectRoot
     });


### PR DESCRIPTION
## Summary
Fix installation path issue where files were being installed to the npm package directory instead of the user's current working directory.

## Problem
Currently when users run:
```bash
npx @stillrivercode/information-dense-keywords
```

The dictionary files are installed to the npm package's location rather than the user's current directory, making them hard to find.

## Root Cause
The `bin/idk-install` script was using `cwd: projectRoot` which runs the install script from the npm package directory, causing relative paths like `./docs` to be relative to the package location.

## Solution
- Calculate absolute path from user's current working directory using `process.cwd()`
- Pass absolute path to install script while still running from package root (needed to find source files)
- Now `./docs` resolves to user's current directory + `/docs`

## Test Results
✅ Files now install to correct location in user's working directory
✅ Custom paths work correctly (e.g., `npx @stillrivercode/information-dense-keywords custom-dir`)
✅ Installation output shows correct absolute paths

## After Merge
Users will get the expected behavior where running the command creates `docs/` in their current directory.

🤖 Generated with [Claude Code](https://claude.ai/code)