### PR TITLE
docs: Update AI.md to use docs/ subdirectories

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -53,21 +53,23 @@ Key files you'll work with:
 
 * `information-dense-keywords.md` - The core dictionary content
 * `README.md` - Project documentation and usage guide
-* `docs/roadmaps/ROADMAP.md` - Development priorities and future plans
+* `docs/roadmaps/` - Development priorities and future plans
+* `docs/plans/` - Plans for new features or changes
+* `docs/specs/` - Specifications for new features
+* `docs/research/` - Research documents
 * `examples/` - Usage examples and guides
 * `adrs/` - Architecture decision records
 * `AI.md` - This shared AI instruction file
-* `CLAUDE.md` - Claude-specific instructions
-* `GEMINI.md` - Gemini-specific instructions
 
 ## Cross-References
 
 * [information-dense-keywords.md](information-dense-keywords.md) - The core command dictionary
 * [README.md](README.md) - Main project documentation
-* [docs/roadmaps/ROADMAP.md](docs/roadmaps/ROADMAP.md) - Development roadmap and priorities
+* [docs/roadmaps/](docs/roadmaps/) - Development roadmap and priorities
+* [docs/plans/](docs/plans/) - Plans for new features or changes
+* [docs/specs/](docs/specs/) - Specifications for new features
+* [docs/research/](docs/research/) - Research documents
 * [examples/ai-usage-guide.md](examples/ai-usage-guide.md) - AI usage examples
-* [CLAUDE.md](CLAUDE.md) - Claude-specific context and instructions
-* [GEMINI.md](GEMINI.md) - Gemini-specific context and instructions
 
 ## Core Principles
 
@@ -80,4 +82,4 @@ Remember: This project focuses on creating a clear, actionable vocabulary for hu
 
 ## AI-Specific Considerations
 
-Each AI assistant should reference this file for common guidance, then refer to their specific instruction file (CLAUDE.md, GEMINI.md, etc.) for platform-specific considerations and capabilities.
+Each AI assistant should reference this file for common guidance, then refer to their specific instruction file for platform-specific considerations and capabilities.


### PR DESCRIPTION
This pull request updates the `AI.md` file to standardize the documentation paths used by AI assistants.

**Changes:**

- The `File Structure` and `Cross-References` sections in `AI.md` have been updated to point to the following directories for storing documentation:
    - `docs/roadmaps/`
    - `docs/plans/`
    - `docs/specs/`
    - `docs/research/`
- This ensures that when AI assistants are instructed to create roadmaps, plans, specs, or research documents, they will create them in a consistent and organized location within the user's project.
- Direct references to `CLAUDE.md` and `GEMINI.md` have been removed from the shared `AI.md` to make the instructions more general.

This change addresses the need to guide AI assistants on where to create files when the `idk` package is used, without creating those directories in the source repository itself.