### PR TITLE
fix: remove unsupported env variable usage in timeout-minutes

### DIFF
--- a/.github/workflows/emergency-controls.yml
+++ b/.github/workflows/emergency-controls.yml
@@ -1,9 +1,5 @@
 name: Emergency Controls
 
-# Centralized timeout configuration
-env:
-  EMERGENCY_TIMEOUT_MINUTES: 10
-
 on:
   workflow_dispatch:
     inputs:
@@ -61,7 +57,9 @@ jobs:
     needs: verify-authorization
     if: needs.verify-authorization.outputs.authorized == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ fromJSON(env.EMERGENCY_TIMEOUT_MINUTES) }}
+    # Note: timeout-minutes doesn't support env variables at job level
+    # If you need to change this, update the value here
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Fix GitHub Actions workflow error in emergency-controls.yml
- Remove unsupported environment variable usage in timeout-minutes field at job level
- Replace with hardcoded value (10 minutes) with explanatory comment

## Context
GitHub Actions doesn't support environment variables in the timeout-minutes field at the job level. This was causing the workflow to fail with:
- "Unrecognized named-value: 'env'"
- "Unexpected value '${{ fromJSON(env.EMERGENCY_TIMEOUT_MINUTES) }}'"

## Solution
Used a hardcoded timeout value with a comment explaining why environment variables can't be used in this context.

🤖 Generated with [Claude Code](https://claude.ai/code)